### PR TITLE
I18n links improvements

### DIFF
--- a/src/i18n/helpers.ts
+++ b/src/i18n/helpers.ts
@@ -28,3 +28,5 @@ export function getEntryFileName(pathname: string) {
 		return pathname !== "/" ? pathname : "/index";
 	}
 }
+
+export const isExternalURL = (url: string) => /^https?:\/\//.test(url);

--- a/src/ui/button-link.tsx
+++ b/src/ui/button-link.tsx
@@ -6,19 +6,16 @@ type ButtonLinkProps = RouterLinkProps & {
 };
 
 export const ButtonLink = (props: ButtonLinkProps) => {
-	const target = () => (props.href.startsWith("http") ? "_blank" : undefined);
 	return (
 		<Dynamic
 			addLocale
-			component={Boolean(target()) ? "a" : A}
+			component={A}
 			classList={{
 				"rounded-full bg-blue-300 py-2 px-4 text-sm font-semibold text-slate-900 hover:bg-blue-200 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300/50 active:bg-blue-500":
 					props.variant === "primary",
 				"rounded-full bg-slate-800 py-2 px-4 text-sm font-medium text-white hover:bg-slate-700 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/50 active:text-slate-300":
 					props.variant === "secondary",
 			}}
-			target={target()}
-			rel={target() === "_blank" ? "noopener noreferrer" : undefined}
 			{...props}
 		/>
 	);

--- a/src/ui/edit-page-link.tsx
+++ b/src/ui/edit-page-link.tsx
@@ -10,7 +10,10 @@ export const EditPageLink: Component = () => {
 	const { pathname } = useLocation();
 
 	const srcPath = createMemo(() => {
-		return `https://github.com/solidjs/solid-docs-next/edit/main/src/routes${getEntryFileName(pathname)}.mdx`;
+		return `https://github.com/solidjs/solid-docs-next/edit/main/src/routes${getEntryFileName(pathname)}.mdx`.replace(
+			"/.mdx",
+			"/index.mdx"
+		);
 	});
 	return (
 		<a

--- a/src/ui/i18n-anchor.tsx
+++ b/src/ui/i18n-anchor.tsx
@@ -3,8 +3,8 @@ import {
 	useLocation,
 	type AnchorProps,
 } from "@solidjs/router";
-import { Show } from "solid-js";
-import { getValidLocaleFromPathname } from "~/i18n/helpers";
+import { Show, splitProps } from "solid-js";
+import { getValidLocaleFromPathname, isExternalURL } from "~/i18n/helpers";
 
 export type RouterLinkProps = AnchorProps & {
 	addLocale?: boolean;
@@ -13,13 +13,26 @@ export type RouterLinkProps = AnchorProps & {
 export function A(props: RouterLinkProps) {
 	const { pathname } = useLocation();
 	const locale = () => getValidLocaleFromPathname(pathname);
+	const external = () => isExternalURL(props.href);
+
+	const [_, rest] = splitProps(props, ["addLocale"]);
 
 	return (
-		<Show when={locale()} fallback={<RouterAnchor {...props} />} keyed>
+		<Show
+			when={!external() && locale()}
+			fallback={
+				<RouterAnchor target="_blank" rel="noopener noreferrer" {...rest} />
+			}
+			keyed
+		>
 			{(loc) => (
 				<RouterAnchor
-					{...props}
-					href={props.addLocale ? `${loc}${props.href}` : props.href}
+					{...rest}
+					href={
+						props.addLocale
+							? `/${loc}${props.href}`.replace(/\/$/, "")
+							: props.href
+					}
 					hreflang={loc}
 					rel="alternate"
 				/>

--- a/src/ui/i18n-anchor.tsx
+++ b/src/ui/i18n-anchor.tsx
@@ -31,7 +31,7 @@ export function A(props: RouterLinkProps) {
 					href={
 						props.addLocale
 							? `/${loc}${props.href}`.replace(/\/$/, "")
-							: props.href
+							: props.href.replace(/\/$/, "")
 					}
 					hreflang={loc}
 					rel="alternate"

--- a/src/ui/markdown-components.tsx
+++ b/src/ui/markdown-components.tsx
@@ -118,9 +118,6 @@ export default {
 		const [, rest] = splitProps(props, ["children"]);
 		const resolved = children(() => props.children);
 		const resolvedArray = resolved.toArray();
-		let extraAttrs = {};
-		if (props.href.startsWith("https://") || props.href.startsWith("http://"))
-			extraAttrs = { target: "_blank", rel: "noopener noreferrer" };
 
 		// Check if the link is a code block
 		if (
@@ -140,7 +137,6 @@ export default {
 				<A
 					addLocale
 					class="[&>code]:shadow-[0_0_0_1.5px_#2563eb] hover:[&>code]:shadow-[0_0_0_2px_#1e3a8a] dark:[&>code]:shadow-[0_0_0_1.5px_#38bdf8] dark:hover:[&>code]:shadow-[0_0_0_2px_#7dd3fc]"
-					{...extraAttrs}
 					{...rest}
 				>
 					{resolved()}
@@ -151,7 +147,6 @@ export default {
 				<A
 					addLocale
 					class={`no-underline shadow-[inset_0_-2px_0_0_var(--tw-prose-background,#38bdf8),inset_0_calc(-1*(var(--tw-prose-underline-size,2px)+2px))_0_0_var(--tw-prose-underline,theme(colors.blue.400))] hover:[--tw-prose-underline-size:4px] dark:[--tw-prose-background:theme(colors.slate.900)] dark:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.blue.500))] dark:hover:[--tw-prose-underline-size:6px] dark:text-blue-300 text-blue-800 font-semibold`}
-					{...extraAttrs}
 					{...rest}
 				>
 					{resolved()}

--- a/src/ui/quick-links.tsx
+++ b/src/ui/quick-links.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "solid-heroicons";
 import { JSXElement, ParentComponent, Show } from "solid-js";
 import { A } from "~/ui/i18n-anchor";
+import { isExternalURL } from "~/i18n/helpers";
 
 import {
 	academicCap,
@@ -32,7 +33,7 @@ export const QuickLinks: ParentComponent<QuickLinksProps> = (props) => {
 					<Icon path={icons[props.icon]} class="h-7 w-7 fill-blue-500" />
 					<div class="text-lg text-slate-900 dark:text-white capitalize no-underline pl-3">
 						<Show
-							when={props.href.match(/https?:\/\//)}
+							when={isExternalURL(props.href)}
 							fallback={
 								<A
 									href={props.href}
@@ -46,8 +47,6 @@ export const QuickLinks: ParentComponent<QuickLinksProps> = (props) => {
 						>
 							<a
 								href={props.href}
-								target="_blank"
-								rel="noopener noreferrer"
 								class="no-underline font-semibold bg-gradient-to-br from-blue-400 to-blue-700 inline-block text-transparent bg-clip-text"
 							>
 								<span class="absolute -inset-px rounded-xl" />


### PR DESCRIPTION
- ensures "edit this page" on the main page when in a locale links to `locale/index.mdx` instead of `locale/.mdx`
- add helper for checking if a URL is external
- `A` component will handle attributes `target` and `rel` for external links using above helper
- fix: internal links within content should be absolute (if link is not absolute then router will append to the route like `pt-br/pt-br/quick-start`
- fix: do not add locale to external links within content
- remove `addLocale` from the html by using `splitProps`
- ensure internal links do not end with a trailing slash